### PR TITLE
Add formatting shortcuts for feedback and correction

### DIFF
--- a/app.js
+++ b/app.js
@@ -70,15 +70,177 @@ wireCustomHandler('zoomIn',  () => nudgeZoom(+Z_STEP));
 wireCustomHandler('zoomOut', () => nudgeZoom(-Z_STEP));
 wireCustomHandler('print',   () => window.print());
 
-/***************
- * Register Parchment formats so classes persist
- ***************/
+ /***************
+  * Register Parchment formats so classes persist
+  ***************/
 const Parchment = Quill.import('parchment');
+const Delta = Quill.import('delta');
 const ParagraphClass = new Parchment.Attributor.Class('paragraphClass', 'paragraph', { scope: Parchment.Scope.BLOCK });
-const BlackIndent    = new Parchment.Attributor.Class('blackIndent',    'black-indent',   { scope: Parchment.Scope.BLOCK });
-const BlueLine       = new Parchment.Attributor.Class('blueLine',       'blue-line',      { scope: Parchment.Scope.BLOCK });
-const BlueSubline    = new Parchment.Attributor.Class('blueSubline',    'blue-subline',   { scope: Parchment.Scope.BLOCK });
-const ParaphraseMain = new Parchment.Attributor.Class('paraphraseMain', 'paraphrase-main',{ scope: Parchment.Scope.BLOCK });
-const ParaphraseMinor= new Parchment.Attributor.Class('paraphraseMinor','paraphrase-minor',{ scope: Parchment.Scope.BLOCK });
-const GreyText       = new Parchment.Attributor.Class('greyText',       'grey-text',      { scope: Parchment.Scope.INLINE });
-const OrigTextAttr   = new Parchment.A
+const BlackIndent = new Parchment.Attributor.Class('blackIndent', 'black-indent', { scope: Parchment.Scope.BLOCK });
+const BlueLine = new Parchment.Attributor.Class('blueLine', 'blue-line', { scope: Parchment.Scope.BLOCK });
+const BlueSubline = new Parchment.Attributor.Class('blueSubline', 'blue-subline', { scope: Parchment.Scope.BLOCK });
+const GreyText = new Parchment.Attributor.Class('greyText', 'grey-text', { scope: Parchment.Scope.INLINE });
+const ParaphraseMainLabel = new Parchment.Attributor.Class('paraphraseMainLabel', 'paraphrase-main-label', { scope: Parchment.Scope.INLINE });
+const ParaphraseMinorLabel = new Parchment.Attributor.Class('paraphraseMinorLabel', 'paraphrase-minor-label', { scope: Parchment.Scope.INLINE });
+
+Quill.register(ParagraphClass, true);
+Quill.register(BlackIndent, true);
+Quill.register(BlueLine, true);
+Quill.register(BlueSubline, true);
+Quill.register(GreyText, true);
+Quill.register(ParaphraseMainLabel, true);
+Quill.register(ParaphraseMinorLabel, true);
+
+/***************
+ * Custom keyboard shortcuts
+ ***************/
+
+function insertArrowLine(index, indent) {
+  const arrow = indent === 0 ? '\u2192' : '\u21B3';
+  const labelAttr = indent === 0 ? { paraphraseMainLabel: true } : { paraphraseMinorLabel: true };
+  const lineAttr = indent === 0 ? { blueLine: true } : { blueSubline: true };
+  const delta = new Delta()
+    .retain(index)
+    .insert(arrow, labelAttr)
+    .insert(' ')
+    .insert('\n', lineAttr);
+  quill.updateContents(delta, 'user');
+  quill.setSelection(index + 2, 0, 'user');
+}
+
+function insertFeedbackBlock() {
+  const range = quill.getSelection();
+  if (!range || range.length === 0) return;
+
+  const selText = quill.getText(range.index, range.length);
+  const mirror = selText.split(/\n/).join('  ');
+
+  // mark original text
+  quill.formatText(range.index, range.length, 'greyText', true);
+
+  // find anchor line
+  let anchorOffset = -1;
+  for (let i = selText.length - 1; i >= 0; i--) {
+    if (/\S/.test(selText[i])) { anchorOffset = i; break; }
+  }
+  let anchorIndex = anchorOffset >= 0 ? range.index + anchorOffset : range.index + range.length;
+  const [anchorLine] = quill.getLine(anchorIndex);
+  let insertIndex = quill.getIndex(anchorLine) + anchorLine.length();
+
+  // skip existing feedback blocks
+  while (true) {
+    const [line] = quill.getLine(insertIndex);
+    if (!line) break;
+    const f = line.formats();
+    if (!f.blackIndent) break;
+    insertIndex += line.length();
+    const [blue] = quill.getLine(insertIndex);
+    if (blue && blue.formats().blueLine) {
+      insertIndex += blue.length();
+      const [sub] = quill.getLine(insertIndex);
+      if (sub && sub.formats().blueSubline) insertIndex += sub.length();
+    }
+  }
+
+  const delta = new Delta()
+    .retain(insertIndex)
+    .insert(mirror + '\n', { blockquote: true, blackIndent: true });
+  quill.updateContents(delta, 'user');
+  insertArrowLine(insertIndex + mirror.length + 1, 0);
+}
+
+function applyCorrection() {
+  const range = quill.getSelection();
+  if (!range || range.length === 0) return;
+  quill.formatText(range.index, range.length, { strike: true, color: 'orange' });
+  quill.insertText(range.index + range.length, '  ', { color: 'orange' }, 'user');
+  quill.insertText(range.index + range.length + 2, ' ', 'user');
+  quill.setSelection(range.index + range.length + 1, 0, 'user');
+}
+
+let bracketStart = null;
+quill.root.addEventListener('keydown', (e) => {
+  if (e.key === '[' && !e.ctrlKey && !e.metaKey) {
+    bracketStart = quill.getSelection()?.index ?? null;
+  } else if (e.key === ']' && bracketStart !== null) {
+    e.preventDefault();
+    const range = quill.getSelection();
+    if (!range) return;
+    const end = range.index;
+    quill.deleteText(bracketStart, 1, 'user');
+    const len = end - bracketStart;
+    quill.formatText(bracketStart, len - 1, { color: 'orange' });
+    quill.insertText(bracketStart + len - 1, ' ', {}, 'user');
+    quill.setSelection(bracketStart + len, 0, 'user');
+    bracketStart = null;
+  }
+});
+
+quill.keyboard.addBinding({ key: '1', shortKey: true }, insertFeedbackBlock);
+quill.keyboard.addBinding({ key: '2', shortKey: true }, applyCorrection);
+
+quill.keyboard.addBinding({ key: 'Enter' }, (range, context) => {
+  const [line] = quill.getLine(range.index);
+  if (!line) return true;
+  const formats = line.formats();
+  const lineIndex = quill.getIndex(line);
+  if (formats.blackIndent) {
+    insertArrowLine(lineIndex + line.length(), 0);
+    return false;
+  }
+  if (formats.blueLine) {
+    const [prevLine] = quill.getLine(lineIndex - 1);
+    if (line.length() <= 3 && prevLine && prevLine.formats().blueLine) {
+      quill.deleteText(lineIndex, 2, 'user');
+      quill.formatLine(lineIndex, 1, { blueLine: false, paragraphClass: true });
+      quill.setSelection(lineIndex, 0, 'user');
+      return false;
+    }
+    insertArrowLine(lineIndex + line.length(), 0);
+    return false;
+  }
+  if (formats.blueSubline) {
+    const [prevLine] = quill.getLine(lineIndex - 1);
+    if (line.length() <= 3 && prevLine && prevLine.formats().blueSubline) {
+      quill.deleteText(lineIndex, 2, 'user');
+      quill.formatLine(lineIndex, 1, { blueSubline: false, paragraphClass: true });
+      quill.setSelection(lineIndex, 0, 'user');
+      return false;
+    }
+    insertArrowLine(lineIndex + line.length(), 1);
+    return false;
+  }
+  return true;
+});
+
+quill.keyboard.addBinding({ key: 9 }, (range, context) => {
+  const [line] = quill.getLine(range.index);
+  if (!line) return true;
+  const formats = line.formats();
+  const lineIndex = quill.getIndex(line);
+  if (formats.blueLine && range.index === lineIndex) {
+    quill.deleteText(lineIndex, 2, 'user');
+    quill.insertText(lineIndex, '\u21B3', { paraphraseMinorLabel: true }, 'user');
+    quill.insertText(lineIndex + 1, ' ', {}, 'user');
+    quill.formatLine(lineIndex, line.length(), { blueLine: false, blueSubline: true });
+    quill.setSelection(lineIndex + 2, 0, 'user');
+    return false;
+  }
+  return true;
+});
+
+quill.keyboard.addBinding({ key: 9, shiftKey: true }, (range, context) => {
+  const [line] = quill.getLine(range.index);
+  if (!line) return true;
+  const formats = line.formats();
+  const lineIndex = quill.getIndex(line);
+  if (formats.blueSubline && range.index === lineIndex) {
+    quill.deleteText(lineIndex, 2, 'user');
+    quill.insertText(lineIndex, '\u2192', { paraphraseMainLabel: true }, 'user');
+    quill.insertText(lineIndex + 1, ' ', {}, 'user');
+    quill.formatLine(lineIndex, line.length(), { blueLine: true, blueSubline: false });
+    quill.setSelection(lineIndex + 2, 0, 'user');
+    return false;
+  }
+  return true;
+});

--- a/styles.css
+++ b/styles.css
@@ -151,6 +151,7 @@ body {
 }
 .ql-editor .paraphrase-main-label,
 .ql-editor .paraphrase-minor-label {
+  color: #0953e2;
   vertical-align: -2px;
   margin-right: 6px;
 }


### PR DESCRIPTION
## Summary
- use Delta ops to apply black-indent and blue-line classes so feedback blocks render with correct blue styling
- color paraphrase arrow labels to match feedback line text

## Testing
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_68acb6a50ae0832a92494ef20350eeb7