### PR TITLE
Prefix custom classes to override Quill styles

### DIFF
--- a/app.js
+++ b/app.js
@@ -76,11 +76,41 @@ wireCustomHandler('resetDoc', () => { /* restore your template */ });
   * Register Parchment formats so classes persist
   ***************/
 const Parchment = Quill.import('parchment');
-const ParagraphClass = new Parchment.Attributor.Class('paragraphClass', 'paragraph', { scope: Parchment.Scope.BLOCK });
-const BlackIndent = new Parchment.Attributor.Class('blackIndent', 'black-indent', { scope: Parchment.Scope.BLOCK });
-const BlueLine = new Parchment.Attributor.Class('blueLine', 'blue-line', { scope: Parchment.Scope.BLOCK });
-const BlueSubline = new Parchment.Attributor.Class('blueSubline', 'blue-subline', { scope: Parchment.Scope.BLOCK });
-const GreyText = new Parchment.Attributor.Class('greyText', 'grey-text', { scope: Parchment.Scope.INLINE });
+const ParagraphClass = new Parchment.Attributor.Class(
+  'paragraphClass',
+  'ql-paragraph',
+  { scope: Parchment.Scope.BLOCK }
+);
+const BlackIndent = new Parchment.Attributor.Class(
+  'blackIndent',
+  'ql-black-indent',
+  { scope: Parchment.Scope.BLOCK }
+);
+const BlueLine = new Parchment.Attributor.Class(
+  'blueLine',
+  'ql-blue-line',
+  { scope: Parchment.Scope.BLOCK }
+);
+const BlueSubline = new Parchment.Attributor.Class(
+  'blueSubline',
+  'ql-blue-subline',
+  { scope: Parchment.Scope.BLOCK }
+);
+const GreyText = new Parchment.Attributor.Class(
+  'greyText',
+  'ql-grey-text',
+  { scope: Parchment.Scope.INLINE }
+);
+const ParaphraseMainLabel = new Parchment.Attributor.Class(
+  'paraphraseMainLabel',
+  'ql-paraphrase-main-label',
+  { scope: Parchment.Scope.INLINE }
+);
+const ParaphraseMinorLabel = new Parchment.Attributor.Class(
+  'paraphraseMinorLabel',
+  'ql-paraphrase-minor-label',
+  { scope: Parchment.Scope.INLINE }
+);
 
 
 Quill.register(ParagraphClass, true);
@@ -88,6 +118,8 @@ Quill.register(BlackIndent, true);
 Quill.register(BlueLine, true);
 Quill.register(BlueSubline, true);
 Quill.register(GreyText, true);
+Quill.register(ParaphraseMainLabel, true);
+Quill.register(ParaphraseMinorLabel, true);
 
 
 /***************

--- a/styles.css
+++ b/styles.css
@@ -115,12 +115,12 @@ body {
 .ql-editor p { margin: 0 0 8px; }
 
 /* ===== Your custom classes (scoped) ===== */
-.ql-editor .paragraph {
+.ql-editor p.ql-paragraph {
   font-size: 0.9rem;
   color: #6e6e6e;
   margin: 0 0 4px;
 }
-.ql-editor .grey-text {
+.ql-editor .ql-grey-text {
   font-size: 1rem;
   color: #6e6e6e;
   text-decoration-line: underline;
@@ -129,28 +129,28 @@ body {
   margin: 0 0 6px;
   display: inline-block;
 }
-.ql-editor blockquote.black-indent {
+.ql-editor blockquote.ql-black-indent {
   color: #020211;
   border-left: 4px solid #cccccc;
   margin: 5px 0 5px 4px;
   padding-left: 16px;
 }
-.ql-editor .blue-line {
+.ql-editor p.ql-blue-line {
   color: #0953e2;
   margin-left: 6px;
   margin-top: 0;
   margin-bottom: 0;
   display: block;
 }
-.ql-editor .blue-subline {
+.ql-editor p.ql-blue-subline {
   color: #0953e2;
   margin-left: 8px;
   margin-top: .25em;
   margin-bottom: .75em;
   display: block;
 }
-.ql-editor .paraphrase-main-label,
-.ql-editor .paraphrase-minor-label {
+.ql-editor .ql-paraphrase-main-label,
+.ql-editor .ql-paraphrase-minor-label {
   vertical-align: -2px;
   margin-right: 6px;
 }


### PR DESCRIPTION
## Summary
- Prefix custom classes with `ql-` and add missing Parchment attributors so Quill applies them.
- Update CSS selectors to target new `ql-` classes for paragraph, blockquote and label formatting.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68adb43444b8832aaed7e4c9824224ff