### PR TITLE
refactor: use class attributors for feedback blocks

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -115,12 +115,12 @@ body {
 .ql-editor p { margin: 0 0 8px; }
 
 /* ===== Your custom classes (scoped) ===== */
-.ql-editor .paragraph {
+.ql-editor .ql-paragraph {
   font-size: 0.9rem;
   color: #6e6e6e;
   margin: 0 0 4px;
 }
-.ql-editor .grey-text {
+.ql-editor .ql-grey-text {
   font-size: 1rem;
   color: #6e6e6e;
   text-decoration-line: underline;
@@ -129,28 +129,28 @@ body {
   margin: 0 0 6px;
   display: inline-block;
 }
-.ql-editor blockquote.black-indent {
+.ql-editor blockquote.ql-black-indent {
   color: #020211;
   border-left: 4px solid #cccccc;
   margin: 5px 0 5px 4px;
   padding-left: 16px;
 }
-.ql-editor .blue-line {
+.ql-editor .ql-blue-line {
   color: #0953e2;
   margin-left: 6px;
   margin-top: 0;
   margin-bottom: 0;
   display: block;
 }
-.ql-editor .blue-subline {
+.ql-editor .ql-blue-subline {
   color: #0953e2;
   margin-left: 8px;
   margin-top: .25em;
   margin-bottom: .75em;
   display: block;
 }
-.ql-editor .paraphrase-main-label,
-.ql-editor .paraphrase-minor-label {
+.ql-editor .ql-paraphrase-main-label,
+.ql-editor .ql-paraphrase-minor-label {
   vertical-align: -2px;
   margin-right: 6px;
 }


### PR DESCRIPTION
## Summary
- switch custom formats to ClassAttributor with `ql-*` classes
- update feedback insertion and keyboard bindings to use new classes
- style paraphrase labels and feedback lines with matching `ql-*` selectors

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae20999658832a8c78750c5fc2de4a