### PR TITLE
Use native list indents for feedback

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -129,31 +129,6 @@ body {
   margin: 0 0 6px;
   display: inline-block;
 }
-.ql-editor blockquote.ql-black-indent {
-  color: #020211;
-  border-left: 4px solid #cccccc;
-  margin: 5px 0 5px 4px;
-  padding-left: 16px;
-}
-.ql-editor .ql-blue-line {
-  color: #0953e2;
-  margin-left: 6px;
-  margin-top: 0;
-  margin-bottom: 0;
-  display: block;
-}
-.ql-editor .ql-blue-subline {
-  color: #0953e2;
-  margin-left: 8px;
-  margin-top: .25em;
-  margin-bottom: .75em;
-  display: block;
-}
-.ql-editor .ql-paraphrase-main-label,
-.ql-editor .ql-paraphrase-minor-label {
-  vertical-align: -2px;
-  margin-right: 6px;
-}
 
 /* Print cleanly */
 @media print {


### PR DESCRIPTION
## Summary
- Replace custom feedback block classes with Quill's built-in bullet list indent levels
- Add Tab/Shift+Tab key bindings to prevent unwanted list indentation
- Remove obsolete indent styling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae315ac388832a9eab0a3bce396e85